### PR TITLE
Fix react-api link on react-introduction.mdx

### DIFF
--- a/packages/state/src/content/docs/react/react-introduction.mdx
+++ b/packages/state/src/content/docs/react/react-introduction.mdx
@@ -7,7 +7,7 @@ sidebar:
 import Persistence from "../../../Components/React/Persistence.astro";
 import EasyExample from "../../../Components/React/EasyExample.astro";
 
-This is a high level overview for how to work with Legend-State in React. See [React API](./react-api) for more specific details. Legend-State supports both React and React Native, but most of the examples are in React for ease of showing live demos.
+This is a high level overview for how to work with Legend-State in React. See [React API](../react-api) for more specific details. Legend-State supports both React and React Native, but most of the examples are in React for ease of showing live demos.
 
 ## Component reactivity
 


### PR DESCRIPTION
fixed a typo on the `react-api` link, it should be `../react-api` instead of `./react-api` which leads to 404