### PR TITLE
docs: fix tracking table matrix

### DIFF
--- a/packages/state/src/content/docs/usage/reactivity.mdx
+++ b/packages/state/src/content/docs/usage/reactivity.mdx
@@ -67,8 +67,11 @@ observe(() => {
 The automatic behavior can be modified with two observable functions:
 
 <div style={{ maxWidth: 300 }}>
-  | Function | Tracked | | ----------- | ------- | | `get()` | yes | |
-  `get(true)` | shallow | | `peek()` | no |
+  |Function | Tracked |
+ | ----------- | ------- |
+ | `get()` | yes | 
+ | `get(true)` | shallow |
+ | `peek()` | no |
 </div>
 
 ### get()


### PR DESCRIPTION
Under the [What tracks](https://legendapp.com/open-source/state/usage/reactivity/#what-tracks) section the table matrix is broken. See screenshot:

<img width="816" alt="Screenshot 2023-10-22 at 7 48 24 am" src="https://github.com/LegendApp/legend-docs/assets/10440327/25d39140-567f-41c2-89b2-4421dbc4faea">

Using the code here and Github is unable to render it as well:
| Function | Tracked | | ----------- | ------- | | get() | yes | | get(true) | shallow | | peek() | no |


### Updates
Updated changes being rendered accurately from Github preview md editor

 |Function | Tracked |
 | ----------- | ------- |
 | `get()` | yes | 
 | `get(true)` | shallow |
 | `peek()` | no |