### PR TITLE
Fix typo/broken link: `fast-` → `fast`

### DIFF
--- a/packages/state/src/content/docs/guides/performance.mdx
+++ b/packages/state/src/content/docs/guides/performance.mdx
@@ -183,7 +183,7 @@ function List() {
 
 The `For` component has an `optimized` prop which takes the optimizations even further. It prevents re-rendering the parent component when possible, so if the array length doesn't change it updates React elements in place instead of the whole list rendering. This massively reduces the rendering time when swapping elements, sorting an array, or replacing some individual elements. But because it reuses React nodes rather than replacing them as usual, it may have unexpected behavior with some types of animations or if you are modifying the DOM externally.
 
-This is how the fast "replace all rows" and "swap rows" speeds in the [benchmark](../../intro/fast-#benchmark) are achieved.
+This is how the fast "replace all rows" and "swap rows" speeds in the [benchmark](../../intro/fast#benchmark) are achieved.
 
 ```jsx
 import { For } from "@legendapp/state/react"

--- a/packages/state/src/content/docs/intro/introduction.mdx
+++ b/packages/state/src/content/docs/intro/introduction.mdx
@@ -49,7 +49,7 @@ Legend-State beats every other state library on just about every metric and is s
   style={{ borderRadius: "1rem" }}
 />
 
-See [Fast 🔥](../fast-) for more details of why Legend-State is so fast.
+See [Fast 🔥](../fast) for more details of why Legend-State is so fast.
 
 ### 3. 🔥 Fine-grained reactivity for minimal renders
 

--- a/packages/state/src/content/docs/intro/why.mdx
+++ b/packages/state/src/content/docs/intro/why.mdx
@@ -12,7 +12,7 @@ Legend-State is an evolution of the state system we've been using internally in 
 
 ## ⚡️ Tiny and FAST
 
-Legend-State is the [fastest React state library](../fast-), designed to be as efficient as possible. It does very little extra work and minimizes renders by only re-rendering components when their observables change. And at only `4kb` it won't hurt your bundle size.
+Legend-State is the [fastest React state library](../fast), designed to be as efficient as possible. It does very little extra work and minimizes renders by only re-rendering components when their observables change. And at only `4kb` it won't hurt your bundle size.
 
 ## 😌 Feels natural
 

--- a/packages/state/src/content/docs/usage/observable.mdx
+++ b/packages/state/src/content/docs/usage/observable.mdx
@@ -249,7 +249,7 @@ state$.text.assign({ value: "hello there" });
 
 ### undefined
 
-Because observables track nodes [by path](../../intro/fast-/#proxy-to-path) and not the underlying data, an observable points to a path within an object regardless of its actual value. So it is perfectly fine to access observables when they are currently undefined in the object.
+Because observables track nodes [by path](../../intro/fast/#proxy-to-path) and not the underlying data, an observable points to a path within an object regardless of its actual value. So it is perfectly fine to access observables when they are currently undefined in the object.
 
 You could to do this to set up a listener to a field whenever it becomes available.
 


### PR DESCRIPTION
few broken links in the docs :)