### PR TITLE
add concistency with `state$` for observable object

### DIFF
--- a/packages/shared/src/Components/Install/Install.tsx
+++ b/packages/shared/src/Components/Install/Install.tsx
@@ -31,7 +31,7 @@ interface Props<T extends string> {
 type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 const tabs: PackageManager[] = ["npm", "yarn", "pnpm", "bun"];
 
-export const state = observable({
+export const state$ = observable({
   packageManager: "npm" as PackageManager,
   exampleCount: 0,
   exampleTheme: "light",
@@ -41,7 +41,7 @@ if (typeof window !== "undefined") {
   configureObservablePersistence({
     pluginLocal: ObservablePersistLocalStorage,
   });
-  persistObservable(state, {
+  persistObservable(state$, {
     local: "state",
   });
 }
@@ -106,14 +106,14 @@ export const Install = observer(function ({
   className?: string;
   uid?: string;
 }) {
-  const manager = state.packageManager.get();
+  const manager = state$.packageManager.get();
 
   return (
     <div className={classNames("mt-6", className)}>
       <Tabs
         name={name + (uid || "")}
         tabs={tabs}
-        activeTab$={state.packageManager}
+        activeTab$={state$.packageManager}
       />
       <pre
         className="!mt-4 astro-code css-variables"

--- a/packages/state/src/Components/React/Persistence.tsx
+++ b/packages/state/src/Components/React/Persistence.tsx
@@ -71,7 +71,7 @@ function App() {
   const renderCount = ++useRef(0).current
 
   const sidebarHeight = () => (
-    State.settings.showSidebar.get() ? 96 : 0
+    state$.settings.showSidebar.get() ? 96 : 0
   )
 
   return (
@@ -80,15 +80,15 @@ function App() {
       <div>Username:</div>
       <Reactive.input
         className="input"
-        $value={State.user.profile.name}
+        $value={state$.user.profile.name}
       />
-      <Button onClick={State.settings.showSidebar.toggle}>
+      <Button onClick={state$.settings.showSidebar.toggle}>
         Toggle footer
       </Button>
       <MotionDiv
         className="footer"
         $animate={() => ({
-           height: State.settings.showSidebar.get() ?
+           height: state$.settings.showSidebar.get() ?
              96 : 0
         })}
       >

--- a/packages/state/src/Components/React/Persistence.tsx
+++ b/packages/state/src/Components/React/Persistence.tsx
@@ -50,7 +50,7 @@ import { useRef } from "react"
 
 enableReactComponents()
 
-const State = observable({
+const state$ = observable({
   settings: { showSidebar: false, theme: 'light' },
   user: {
     profile: { name: '', avatar: '' },
@@ -59,7 +59,7 @@ const State = observable({
 })
 
 // Persist state
-persistObservable(State, {
+persistObservable(state$, {
   local: 'persistenceExample',
   pluginLocal: ObservablePersistLocalStorage,
 })

--- a/packages/state/src/content/docs/intro/introduction.mdx
+++ b/packages/state/src/content/docs/intro/introduction.mdx
@@ -16,6 +16,8 @@ There is no boilerplate and there are no contexts, actions, reducers, dispatcher
 
 React components can track access to `get()` on any observable and automatically re-render whenever it changes.
 
+In this documentation, we use `state$` as a convention to indicate an observable. However, you can use any variable name of your preference.
+
 ```jsx
 // Create an observable object
 const state$ = observable({ settings: { theme: "dark" } });
@@ -26,7 +28,7 @@ state$.settings.theme.set("light");
 
 // observe re-runs when accessed observables change
 observe(() => {
-  console.log(state.settings.theme.get());
+  console.log(state$.settings.theme.get());
 });
 
 // Enable React components to automatically track observables

--- a/packages/state/src/content/docs/other/migrating.mdx
+++ b/packages/state/src/content/docs/other/migrating.mdx
@@ -496,11 +496,11 @@ obs.text = 'hi'
 `ref` was a bit unclear and conflicted with React - the new feature to [directly render observables](../../react/fine-grained-reactivity/#render-an-observable-directly) requires a `ref` property. So it is now renamed to `obs`, which feels more intuitive as it is used to get an observable.
 
 ```js
-const state = observable({ text: "" });
+const state$ = observable({ text: "" });
 
 // Before
-const textRef = state.ref("text");
-const textRef2 = state.text.ref();
+const textRef = state$.ref("text");
+const textRef2 = state$.text.ref();
 
 // Now
 const textObs = obs.obs("text");

--- a/packages/state/src/content/docs/react/react-API.mdx
+++ b/packages/state/src/content/docs/react/react-API.mdx
@@ -26,11 +26,11 @@ See [Tracking](../reactivity#observing-contexts) for more about when it tracks.
 import { observable } from "@legendapp/state"
 import { observer } from "@legendapp/state/react"
 
-const state = observable({ count: 0 })
+const state$ = observable({ count: 0 })
 
 const Component = observer(function Component() {
   // Accessing state automatically makes this component track changes to re-render
-  const count = state.count.get()
+  const count = state$.count.get()
 
   // Re-renders whenever count changes
   return <div>{count}</div>
@@ -50,14 +50,14 @@ Props:
 import { observable } from "@legendapp/state"
 import { useSelector } from "@legendapp/state/react"
 
-const state = observable({ selected: 1, theme })
+const state$ = observable({ selected: 1, theme })
 
 const Component = ({ id }) => {
     // Only re-renders if the return value changes
-    const isSelected = useSelector(() => id === state.selected.get())
+    const isSelected = useSelector(() => id === state$.selected.get())
 
     // Get the raw value of an observable and listen to it
-    const theme = useSelector(state.theme)
+    const theme = useSelector(state$.theme)
 
     ...
 }
@@ -110,27 +110,27 @@ import { useObserve, useObservable, Reactive } from "@legendapp/state/react";
 const eventUpdateTitle = event();
 
 function ProfilePage() {
-  const profile = useObservable({ name: "" });
+  const profile$ = useObservable({ name: "" });
 
   // This runs whenever profile changes
   useObserve(() => {
-    document.title = `${profile.name.get()} - Profile`;
+    document.title = `${profile$.name.get()} - Profile`;
   });
 
   // Observe a single observable with a callback when it changes
-  useObserve(profile.name, ({ value }) => {
+  useObserve(profile$.name, ({ value }) => {
     document.title = `${value} - Profile`;
   });
 
   // Observe an event with a callback when it changes
   useObserve(eventUpdateTitle, () => {
-    document.title = `${profile.name.get()} - Profile`;
+    document.title = `${profile$.name.get()} - Profile`;
   });
 
   return (
     <div>
       <span>Name:</span>
-      <Reactive.input $value={profile.name} />
+      <Reactive.input $value={profile$.name} />
     </div>
   );
 }
@@ -200,10 +200,10 @@ import { useObservableReducer } from "@legendapp/state/react"
 
 const Component = () => {
     // Only re-renders if the return value changes
-    const isSelected = useObservableReducer()
+    const isSelected$ = useObservableReducer()
 
     // Get the value of the reducer
-    const theme = isSelected.get()
+    const theme = isSelected$.get()
 
     ...
 }

--- a/packages/state/src/content/docs/usage/configuring.mdx
+++ b/packages/state/src/content/docs/usage/configuring.mdx
@@ -88,19 +88,19 @@ Now you can access/modify observables directly.
 ```js
 import { observable } from "@legendapp/state"
 
-const state = observable({ test: "hi", num: 0 })
+const state$ = observable({ test: "hi", num: 0 })
 
 // $ is a shorthand for get()
-const testValue = state.test.$
+const testValue = state$.test.$
 
 // Assign to $ as a shorthand for set()
-state.test.$ = "hello"
+state$.test.$ = "hello"
 
 // Assign objects too just like you can with set()
-state.$ = { test: "hello" }
+state$.$ = { test: "hello" }
 
 // Incrementing works as you'd expect
-state.num.$++
+state$.num.$++
 ```
 
 ### enableDirectPeek
@@ -117,16 +117,16 @@ Now you can access/modify observables directly without notifying.
 ```js
 import { observable } from "@legendapp/state"
 
-const state = observable({ test: "hi", num: 0 })
+const state$ = observable({ test: "hi", num: 0 })
 
 // _ is a shorthand for peek()
-const testValue = state.test._
+const testValue = state$.test._
 
 // Assign to _ to modify the underlying object without notifying listeners
-state.test._ = "hello"
+state$.test._ = "hello"
 
 // Assign objects too
-state._ = { test: "hello" }
+state$._ = { test: "hello" }
 ```
 
 ### enableReactUse (deprecated)

--- a/packages/state/src/content/docs/usage/helper-functions.mdx
+++ b/packages/state/src/content/docs/usage/helper-functions.mdx
@@ -70,13 +70,13 @@ An optional second parameter lets you use an existing observable for storing the
 import { observable } from '@legendapp/state'
 import { trackHistory } from '@legendapp/state/history'
 
-const state = observable({ profile: { name: 'Hello' }})
+const state$ = observable({ profile: { name: 'Hello' }})
 
 // Track all changes to state
-const history = trackHistory(state)
+const history = trackHistory(state$)
 
 // Change something in state
-state.profile.name.set('Annyong')
+state$.profile.name.set('Annyong')
 
 // History shows the previous value when it changed:
 {

--- a/packages/state/src/content/docs/usage/observable.mdx
+++ b/packages/state/src/content/docs/usage/observable.mdx
@@ -254,9 +254,9 @@ Because observables track nodes [by path](../../intro/fast/#proxy-to-path) and n
 You could to do this to set up a listener to a field whenever it becomes available.
 
 ```jsx
-const state = observable({ user: undefined });
+const state$ = observable({ user: undefined });
 
-when(state.user.uid, (uid) => {
+when(state$.user.uid, (uid) => {
   // Handle login
 });
 ```
@@ -264,14 +264,14 @@ when(state.user.uid, (uid) => {
 Or you could set a value inside an undefined object, and it will fill out the object tree to make it work.
 
 ```jsx
-const state = observable({ user: undefined });
+const state$ = observable({ user: undefined });
 
 observe(() => {
   // This will be undefined until the full user profile is set
-  console.log(`Name: ${state.user.profile.name.get()}`);
+  console.log(`Name: ${state$.user.profile.name.get()}`);
 });
 
-state.user.profile.name.set("Annyong");
+state$.user.profile.name.set("Annyong");
 
 // state == { user: { profile: { name: 'Annyong' } } }
 ```

--- a/packages/state/src/content/docs/usage/reactivity.mdx
+++ b/packages/state/src/content/docs/usage/reactivity.mdx
@@ -23,13 +23,13 @@ Most functions in Legend-State take what we call a "Selector", which either a si
 
 These operation do not track:
 
-1. Accessing through an observable: `state.settings`
+1. Accessing through an observable: `state$.settings`
 2. Call `peek()` on an observable: `settings.peek()`
 
 ### Observing examples
 
 ```js
-const state = observable({
+const state$ = observable({
   settings: {
     theme: "dark",
   },
@@ -40,27 +40,27 @@ const state = observable({
 
 observe(() => {
   // Example 1:
-  const theme = state.settings.theme.get();
-  // ✅ Tracking [state.settings.theme] because of get()
+  const theme = state$.settings.theme.get();
+  // ✅ Tracking [state$.settings.theme] because of get()
 
   // Example 2:
-  const settings = state.settings;
+  const settings = state$.settings;
   // ❌ Not tracking because it's an object
 
   const theme = settings.theme.get();
-  // ✅ Tracking [state.settings.theme] because of get()
+  // ✅ Tracking [state$.settings.theme] because of get()
 
   // Example 3:
-  const theme$ = state.settings.theme;
+  const theme$ = state$.settings.theme;
   // ❌ Not tracking with no get()
 
   // Example 4:
-  state.chats.messages.map((m) => <Message key={m.get().id} message={m} />);
-  // ✅ Tracking [state.chats.messages (shallow)] because of map()
+  state$.chats.messages.map((m) => <Message key={m.get().id} message={m} />);
+  // ✅ Tracking [state$.chats.messages (shallow)] because of map()
 
   // Example 5:
-  Object.keys(state.settings);
-  // ✅ Tracking [state.settings (shallow)]
+  Object.keys(state$.settings);
+  // ✅ Tracking [state$.settings (shallow)]
 });
 ```
 
@@ -91,11 +91,11 @@ const theme = state.settings.theme.get();
 `get()` observes recursively by default, so any child changing will cause an update. You can modify it to be a shallow listener by just adding a `true` parameter. This can be useful when a component only needs to re-render if an object's keys or an array's items change.
 
 ```jsx
-const state = observable({ messages: [] });
+const state$ = observable({ messages: [] });
 
 observe(() => {
   // Only need this to update when messages added/removed
-  const messages = state.messages.get(true);
+  const messages = state$.messages.get(true);
 
   console.log("Latest message", messages[0]);
 });
@@ -118,17 +118,17 @@ The callback parameter has some useful properties:
 
 ```js
 import { observe, observable } from "@legendapp/state";
-const state = observable({ isOnline: false, toasts: [] });
+const state$ = observable({ isOnline: false, toasts: [] });
 
 const dispose = observe((e) => {
   // This observe will automatically track state.isOnline for changes
-  if (!state.isOnline.get()) {
+  if (!state$.isOnline.get()) {
     // Show an "Offline" toast when offline
     const toast = { id: "offline", text: "Offline", color: "red" };
-    state.toasts.push(toast);
+    state$.toasts.push(toast);
 
     // Remove the toast when the observe is re-run, which will be when isOnline becomes true
-    e.onCleanup = () => state.toasts.splice(state.toasts.indexOf(toast), 1);
+    e.onCleanup = () => state$.toasts.splice(state$.toasts.indexOf(toast), 1);
   }
 });
 
@@ -140,12 +140,12 @@ Or use the second parameter to run a reaction when a selector changes. It has an
 
 ```js
 // Observe the return value of a selector and observe all accessed observables
-observe(state.isOnline, (e) => {
+observe(state$.isOnline, (e) => {
   console.log("Online status", e.value);
 });
 // Observe the return value of a selector and observe all accessed observables
 observe(
-  () => state.isOnline.get() && state.user.get(),
+  () => state$.isOnline.get() && state$.user.get(),
   (e) => {
     console.log("Signed in status", e.value);
   }


### PR DESCRIPTION
Hey, thanks for this great library, i will use it on my project. 🙌
_Please, correct me if I am wrong of feel free to close this PR if's irrelevant._

Reading the doc as a React Native dev, I found confusing sometime we are using...
```
const state$ = observable({
```
...and sometime not
```
const state = observable({
```


So I made a small survey 
https://twitter.com/flexbox_/status/1746830487652270213

and the internet seams to use `state$` for observable values
