### PR TITLE
Docs/update config imports

### DIFF
--- a/packages/state/src/content/docs/usage/configuring.mdx
+++ b/packages/state/src/content/docs/usage/configuring.mdx
@@ -93,7 +93,7 @@ function Component() {
 
 See [Reactive components](../../react/fine-grained-reactivity/#reactive-components) for more details.
 
-## enable$get
+## enable$GetSet
 
 This enables accessing and setting the raw value of an observable directly. It's a shorthand for `get()` and `set(...)`.
 
@@ -122,7 +122,7 @@ state$.$ = { test: "hello" }
 state$.num.$++
 ```
 
-## enable_peek
+## enable_PeekAssign
 
 This enables accessing and setting the raw value of an observable directly without tracking or notifying listeners. Getting with `._` is a shorthand for `peek()` and assigning to `._` modifies the underlying data without notifying. Modifying data without notifying is likely necessary in only very specific scenarios so use it with care.
 

--- a/packages/state/src/content/docs/usage/configuring.mdx
+++ b/packages/state/src/content/docs/usage/configuring.mdx
@@ -98,8 +98,8 @@ See [Reactive components](../../react/fine-grained-reactivity/#reactive-componen
 This enables accessing and setting the raw value of an observable directly. It's a shorthand for `get()` and `set(...)`.
 
 ```js
-import { enable$get } from "@legendapp/state/config/enable$get"
-enable$get()
+import { enable$GetSet } from "@legendapp/state/config/enable$GetSet";
+enable$GetSet();
 ```
 
 Now you can access/modify observables directly.
@@ -127,8 +127,8 @@ state$.num.$++
 This enables accessing and setting the raw value of an observable directly without tracking or notifying listeners. Getting with `._` is a shorthand for `peek()` and assigning to `._` modifies the underlying data without notifying. Modifying data without notifying is likely necessary in only very specific scenarios so use it with care.
 
 ```js
-import { enable_peek } from "@legendapp/state/config/enable_peek"
-enable_peek()
+import { enable_PeekAssign } from "@legendapp/state/config/enable_PeekAssign";
+enable_PeekAssign();
 ```
 
 Now you can access/modify observables directly without notifying.


### PR DESCRIPTION
This PR updates the headers and examples to reflect the latest changes in v3:
- `enable$get` is now `enable$GetSet`
- `enable_peek` is now `enable_PeekAssign`