### PR TITLE
fix 404 link page for observer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ This is the documentation for all of [Legend's](https://legendapp.com) open-sour
 
 The documentation uses [Starlight by Astro](https://starlight.astro.build/), with live editing using [React-Live](https://github.com/FormidableLabs/react-live), and example components built in React.
 
-# Running
+## Running
 
 You can run everything locally with Astro to edit the examples yourself. It uses [bun](https://bun.sh/), though it would probably work with a different package manager.
 
-First cd into the state folder, `bun i` to install the packages and `bun dev` to get started.
+```bash
+cd packages/state
+bun i
+bun dev
+```
 
-# Contributing
+## Contributing
 
 We welcome any contributions you'd like to make! If there are any typos or mistakes, additional explanation needed, or you'd like to add more examples, we would love your help.
 
-If you want to make a larger change like adding a page or restructuring, it would be good to have a discussion about that first, so please post an issue or discussion.
+If you want to make a larger change like adding a page or restructuring, it would be good to have a discussion about that first, so please [post an issue](https://github.com/LegendApp/legend-docs/issues/new).

--- a/packages/state-v2/src/content/docs/usage/configuring.mdx
+++ b/packages/state-v2/src/content/docs/usage/configuring.mdx
@@ -38,7 +38,7 @@ function Component() {
 :::caution[Caution: Rules of hooks]
 Under the hood this replaces the `get()` with a `useSelector` hook so it is subject to the rules of hooks. That means it can cause problems if you use `get()` conditionally or within a dynamic loop.
 
-We recommend that you use this while getting started and for rapid prototyping. Then wrap your components with [observer](../react-api/#observer) for improved performance and safety.
+We recommend that you use this while getting started and for rapid prototyping. Then wrap your components with [observer](../../react/react-api/#observer) for improved performance and safety.
 :::
 
 ### enableReactComponents, enableReactNativeComponents

--- a/packages/state/src/content/docs/usage/configuring.mdx
+++ b/packages/state/src/content/docs/usage/configuring.mdx
@@ -57,7 +57,7 @@ Note that `enableReactTracking` and `observer` can be used together - observer w
 :::caution[Caution: Rules of hooks]
 Under the hood this replaces the `get()` with a `useSelector` hook so it is subject to the rules of hooks. That means it can cause problems if you use `get()` conditionally or within a dynamic loop.
 
-We recommend that you use this while getting started and for rapid prototyping. Then wrap your components with [observer](../react-api/#observer) for improved performance and safety.
+We recommend that you use this while getting started and for rapid prototyping. Then wrap your components with [observer](../../react/react-api/#observer) for improved performance and safety.
 :::
 
 ## enableReactComponents, enableReactNativeComponents


### PR DESCRIPTION
- little typo `configuring.mdx`
- I made crystal clear on how to contribute on the README