### PR TITLE
update supabase plugin docs to reflect the current set() api

### DIFF
--- a/packages/state/src/content/docs/sync/supabase.mdx
+++ b/packages/state/src/content/docs/sync/supabase.mdx
@@ -49,12 +49,12 @@ const messages = messages$.get()
 function addMessage(text: string) {
     const id = generateId()
     // Add keyed by id to the messages$ observable to trigger a create in Supabase
-    messages$[id].set({
+    messages$[id].set(() => ({
         id,
         text,
         createdAt: undefined,
         updatedAt: undefined
-    })
+    }))
 }
 
 function updateMessage(id: string, text: string) {


### PR DESCRIPTION
Ran into issues using the example code in the docs, see issue in legend-state repo here: https://github.com/LegendApp/legend-state/issues/323

This change updates the docs to reflect the current `set()` api shape. 