### PR TITLE
Update persist-sync.mdx

### DIFF
--- a/packages/state/src/content/docs/sync/persist-sync.mdx
+++ b/packages/state/src/content/docs/sync/persist-sync.mdx
@@ -549,11 +549,9 @@ import { observablePersistIndexedDB } from "@legendapp/state/persist-plugins/ind
 const persistOptions = configureSynced({
     persist: {
         plugin: observablePersistIndexedDB({
-            indexedDB: {
-                databaseName: "Legend",
-                version: 1,
-                tableNames: ["documents", "store"]
-            }
+            databaseName: "Legend",
+            version: 1,
+            tableNames: ["documents", "store"]
         })
     }
 })


### PR DESCRIPTION
Hi, I guess this shape is from v2, it's no longer contained in an `indexedDB` object:

```ts
interface ObservablePersistIndexedDBPluginOptions {
    databaseName: string;
    version: number;
    tableNames: string[];
    deleteTableNames?: string[];
    onUpgradeNeeded?: (event: IDBVersionChangeEvent) => void;
}
```