### PR TITLE
fix(State): update local persistence syntax in Persistence.tsx

### DIFF
--- a/packages/state/src/Components/React/Persistence.tsx
+++ b/packages/state/src/Components/React/Persistence.tsx
@@ -56,8 +56,10 @@ const state$ = observable({
 
 // Persist state
 syncObservable(state$, {
-  local: 'persistenceExample',
-  pluginLocal: ObservablePersistLocalStorage,
+  persist:{
+    name: 'persistenceExample',
+    plugin: ObservablePersistLocalStorage,
+  }
 })
 
 // Create a reactive Framer-Motion div


### PR DESCRIPTION
### PR Description

#### Summary
This PR updates the state persistence configuration in the `Persistence.tsx` file to use the correct syntax for `syncObservable`. The previous implementation used an outdated configuration, which could lead to unexpected behavior in the persistence functionality.

Closes: [#31](https://github.com/LegendApp/legend-docs/issues/31)


#### Changes Made
- Refactored the `syncObservable` configuration in the `Persistence.tsx` file.
- Replaced the deprecated `local` and `pluginLocal` keys with the updated `persist` object structure.

#### Why This Change Is Necessary
The previous configuration did not align with the current standard for state persistence, and updating it ensures that the component behaves as expected. The new structure improves maintainability and consistency with other components.
