### PR TITLE
[Crud] Fix `fieldDeleted` instead of `fieldUpdated`

### DIFF
--- a/packages/state/src/content/docs/sync/crud.mdx
+++ b/packages/state/src/content/docs/sync/crud.mdx
@@ -122,7 +122,7 @@ Alternatively if you do soft deletes, you can provide a `fieldDeleted` option in
 const profile$ = observable(syncedCrud({
     // ...
     update: () => {/* ... */},
-    fieldUpdated: 'deleted'
+    fieldDeleted: 'deleted'
 }))
 ```
 


### PR DESCRIPTION
Fixes `fieldDeleted` instead of `fieldUpdated` in Crud soft delete documentation.