### PR TITLE
Sync CRUD update references wrong option.

### DIFF
--- a/packages/state/src/content/docs/sync/crud.mdx
+++ b/packages/state/src/content/docs/sync/crud.mdx
@@ -93,7 +93,7 @@ const profile$ = observable(syncedCrud({
             return data;
         }
     },
-    fieldCreatedAt: 'updated_at',
+    fieldUpdatedAt: 'updated_at',
     updatePartial: true // Update with only changed fields
 }))
 ```


### PR DESCRIPTION
The update section is referring to the "fieldCreatedAt" when it should be "fieldUpdatedAt".