### PR TITLE
docs(state): clarify observable() input is the underlying data

### DIFF
--- a/docs/content/state/v3/usage/observable.mdx
+++ b/docs/content/state/v3/usage/observable.mdx
@@ -557,3 +557,32 @@ const list = list$.get()
 const idx = list.findIndex((item) => item.id === itemId)
 list$[idx].delete()
 ```
+
+#### 3. The initial value passed to `observable()` is the underlying data
+
+Following from above: when you pass an object or array to `observable()`, that value becomes the underlying data — it is not cloned. As you call `.set()` on fields, the original object is mutated in place. This is intentional and what makes Legend-State fast, but it surprises people coming from libraries that treat their input as immutable (Zustand/Redux/MobX).
+
+A common pitfall is reusing a shared `initialState` constant as a "reset target":
+
+```js
+const initialState = { onboardingCompleted: false, name: '' }
+const state$ = observable(initialState)
+
+state$.onboardingCompleted.set(true)
+console.log(initialState)
+// { onboardingCompleted: true, name: '' }   ← mutated in place
+
+state$.set(initialState)
+// ❌ no-op: `initialState` IS the current value, so deep-equality check skips notify
+```
+
+If you want a stable reset target, use a factory so each call produces a fresh object:
+
+```js
+const createInitialState = () => ({ onboardingCompleted: false, name: '' })
+
+const state$ = observable(createInitialState())
+state$.onboardingCompleted.set(true)
+
+state$.set(createInitialState())  // ✅ fresh object, set fires
+```


### PR DESCRIPTION
Adds a third sub-section under **"Observables are mutable"** on the [Observable](https://legendapp.com/open-source/state/v3/usage/observable/) page, explaining that the value passed to `observable()` is not cloned — it becomes the underlying data and is mutated in place as fields are updated.

The existing section #1 covers the symptom ("set it back onto the observable, that just sets it to itself") but doesn't connect it back to the original input. The new sub-section calls out the most common pitfall — reusing a shared `initialState` constant as a reset target — and shows the factory pattern as the fix.

Refs [LegendApp/legend-state#647](https://github.com/LegendApp/legend-state/issues/647) — when investigating that issue I audited my own codebase and found 8 stores with silently broken reset functions from this exact pattern.

No structural changes to the page — just a new sub-section appended to the existing list.

---
_Disclosure: written together with Claude (Anthropic). Verified locally._