### PR TITLE
docs: replace Medium links with the bretcameron blog

### DIFF
--- a/docs/content/state/v2/intro/fast.mdx
+++ b/docs/content/state/v2/intro/fast.mdx
@@ -52,7 +52,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/content/state/v3/intro/fast.mdx
+++ b/docs/content/state/v3/intro/fast.mdx
@@ -51,7 +51,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/public/state/v2/llms-full.md
+++ b/docs/public/state/v2/llms-full.md
@@ -653,7 +653,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/public/state/v2/llms-full.txt
+++ b/docs/public/state/v2/llms-full.txt
@@ -653,7 +653,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/public/state/v2/llms/intro/fast.md
+++ b/docs/public/state/v2/llms/intro/fast.md
@@ -47,7 +47,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/public/state/v3/llms-full.md
+++ b/docs/public/state/v3/llms-full.md
@@ -296,7 +296,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/public/state/v3/llms-full.txt
+++ b/docs/public/state/v3/llms-full.txt
@@ -296,7 +296,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 

--- a/docs/public/state/v3/llms/intro/fast.md
+++ b/docs/public/state/v3/llms/intro/fast.md
@@ -47,7 +47,7 @@ Proxying by path also enables some really interesting list optimizations: in the
 
 ### Listeners at each node
 
-Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://bretcameron.medium.com/how-to-make-your-code-faster-using-javascript-sets-b432457a4a77).
+Each node keeps a `Set` of listeners so that you can listen to changes to any value anywhere within the state. This is great for performance because changes only call the few listeners that are affected by that change. JavaScript's `Set` provides nice benefits here as its uniquenesss constraint ensures callbacks are added only once, and removing listeners is an [instant O(1) operation](https://www.bretcameron.com/blog/how-to-make-your-code-faster-using-javascript-sets).
 
 ### Granular renders
 


### PR DESCRIPTION
## What

This PR replaces the Medium article links and references in the docs with their equivalents on the bretcameron blog.

## Why

Medium puts most of its content behind a paywall, so readers without a Medium membership are unable to read the articles that the documentation points to. The same content is freely available on the bretcameron blog, so pointing users there keeps the references accessible to everyone.

## Changes

* Updated the outbound links that previously pointed to Medium so they now point to the matching posts on the bretcameron blog.
* Updated the surrounding text where it mentioned Medium so it stays consistent with the new source.

No content or wording of the documentation itself was changed beyond the link and reference updates.